### PR TITLE
be explicit about azimuthal and polar angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,12 +380,11 @@ Integration on the sphere can also be done for function defined in spherical
 coordinates:
 ```python
 val = quadpy.sphere.integrate_spherical(
-    lambda phi_theta: numpy.sin(phi_theta[0])**2 * numpy.sin(phi_theta[1]),
+    lambda azimuthal_polar: numpy.sin(azimuthal_polar[0])**2 * numpy.sin(azimuthal_polar[1]),
     radius=1.0,
     rule=quadpy.sphere.Lebedev(19)
     )
 ```
-Note that `phi_theta[0]` is the azimuthal, `phi_theta[1]` the polar angle here.
 
 ### Ball
 <img src="https://nschloe.github.io/quadpy/ball.png" width="25%">

--- a/quadpy/sphere/albrecht_collatz.py
+++ b/quadpy/sphere/albrecht_collatz.py
@@ -63,5 +63,5 @@ class AlbrechtCollatz(object):
                 ]
 
         self.points, self.weights = untangle(data)
-        self.phi_theta = cartesian_to_spherical_sympy(self.points)
+        self.azimuthal_polar = cartesian_to_spherical_sympy(self.points)
         return

--- a/quadpy/sphere/heo_xu.py
+++ b/quadpy/sphere/heo_xu.py
@@ -367,7 +367,7 @@ class HeoXu(object):
                 ]
 
         self.points, self.weights = untangle(data)
-        self.phi_theta = cartesian_to_spherical(self.points)
+        self.azimuthal_polar = cartesian_to_spherical(self.points)
         return
 
 

--- a/quadpy/sphere/lebedev.py
+++ b/quadpy/sphere/lebedev.py
@@ -20,10 +20,10 @@ class Lebedev(object):
     <https://people.sc.fsu.edu/~jburkardt/datasets/sphere_lebedev_rule/sphere_lebedev_rule.html>
     '''
     # It's a little unclear how to best store the original data. By Burkhardt,
-    # it is given in terms of phi and theta, however those angles are not well
-    # suited to express the symmetry. For that, this code converts the
-    # spherical coordinates into Cartesians, applies the symmetry
-    # transformations, and converts back.
+    # it is given in terms of the spherical coordinates phi and theta, however
+    # those angles are not well suited to express the symmetry. For that, this
+    # code converts the spherical coordinates into Cartesians, applies the
+    # symmetry transformations, and converts back.
     def __init__(self, degree):
         self.degree = degree
         if degree == 3:
@@ -1411,18 +1411,18 @@ class Lebedev(object):
                 (1.9055344987300001e-04, _rsw(1.3716092309148088e-02, 2.3708499670410427e-01))
                 ]
 
-        self.phi_theta, self.weights = untangle(data)
-        self.points = _spherical_to_cartesian(self.phi_theta)
+        self.azimuthal_polar, self.weights = untangle(data)
+        self.points = _spherical_to_cartesian(self.azimuthal_polar)
         return
 
 
-def _spherical_to_cartesian(phi_theta):
-    sin_phi_theta = numpy.sin(phi_theta)
-    cos_phi_theta = numpy.cos(phi_theta)
+def _spherical_to_cartesian(azimuthal_polar):
+    sin_azimuthal_polar = numpy.sin(azimuthal_polar)
+    cos_azimuthal_polar = numpy.cos(azimuthal_polar)
     return numpy.stack([
-        sin_phi_theta[:, 1] * cos_phi_theta[:, 0],
-        sin_phi_theta[:, 1] * sin_phi_theta[:, 0],
-        cos_phi_theta[:, 1],
+        sin_azimuthal_polar[:, 1] * cos_azimuthal_polar[:, 0],
+        sin_azimuthal_polar[:, 1] * sin_azimuthal_polar[:, 0],
+        cos_azimuthal_polar[:, 1],
         ], axis=1)
 
 
@@ -1541,19 +1541,19 @@ def _llm(beta):
     return cartesian_to_spherical(X)
 
 
-def _rsw(phi, theta):
+def _rsw(azimuthal, polar):
     # translate the point into cartesian coords; note that phi=pi/4.
-    phi *= numpy.pi
-    theta *= numpy.pi
+    azimuthal *= numpy.pi
+    polar *= numpy.pi
 
-    sin_theta = numpy.sin(theta)
-    cos_theta = numpy.cos(theta)
-    sin_phi = numpy.sin(phi)
-    cos_phi = numpy.cos(phi)
+    sin_polar = numpy.sin(polar)
+    cos_polar = numpy.cos(polar)
+    sin_azimuthal = numpy.sin(azimuthal)
+    cos_azimuthal = numpy.cos(azimuthal)
 
-    r = sin_theta * cos_phi
-    s = sin_theta * sin_phi
-    w = cos_theta
+    r = sin_polar * cos_azimuthal
+    s = sin_polar * sin_azimuthal
+    w = cos_polar
 
     X = numpy.array([
         [+r, +s, +w],

--- a/quadpy/sphere/mclaren.py
+++ b/quadpy/sphere/mclaren.py
@@ -275,5 +275,5 @@ class McLaren(object):
                 ]
 
         self.points, self.weights = untangle(data)
-        self.phi_theta = cartesian_to_spherical_sympy(self.points)
+        self.azimuthal_polar = cartesian_to_spherical_sympy(self.points)
         return

--- a/quadpy/sphere/stroud.py
+++ b/quadpy/sphere/stroud.py
@@ -50,7 +50,7 @@ class Stroud(object):
             self.weights /= 4 * numpy.pi
             flt = numpy.vectorize(float)
             self.points = flt(scheme.points)
-            self.phi_theta = cartesian_to_spherical(self.points)
+            self.azimuthal_polar = cartesian_to_spherical(self.points)
         elif index == 'U3 11-3':
             self.set_data(McLaren(9))
         else:
@@ -62,5 +62,5 @@ class Stroud(object):
         self.degree = scheme.degree
         self.weights = scheme.weights
         self.points = scheme.points
-        self.phi_theta = scheme.phi_theta
+        self.azimuthal_polar = scheme.azimuthal_polar
         return

--- a/quadpy/sphere/tools.py
+++ b/quadpy/sphere/tools.py
@@ -49,12 +49,12 @@ def _plot_mpl(scheme):
 
 def _plot_spherical_cap_mpl(ax, b, opening_angle, color, elevation=1.01):
     r = elevation
-    phi = numpy.linspace(0, 2 * numpy.pi, 30)
-    theta = numpy.linspace(0, opening_angle, 20)
+    azimuthal = numpy.linspace(0, 2 * numpy.pi, 30)
+    polar = numpy.linspace(0, opening_angle, 20)
     X = r * numpy.stack([
-        numpy.outer(numpy.cos(phi), numpy.sin(theta)),
-        numpy.outer(numpy.sin(phi), numpy.sin(theta)),
-        numpy.outer(numpy.ones(numpy.size(phi)), numpy.cos(theta)),
+        numpy.outer(numpy.cos(azimuthal), numpy.sin(polar)),
+        numpy.outer(numpy.sin(azimuthal), numpy.sin(polar)),
+        numpy.outer(numpy.ones(numpy.size(azimuthal)), numpy.cos(polar)),
         ], axis=-1)
 
     # rotate X such that [0, 0, 1] gets rotated to `c`;
@@ -92,12 +92,9 @@ def integrate(f, center, radius, rule, sumfun=helpers.kahan_sum):
 
 
 def integrate_spherical(f, radius, rule, sumfun=helpers.kahan_sum):
-    '''Quadrature where `f` is defined in spherical coordinates `phi`, `theta`.
-
-    This is using the ISO 31-11 convection of `theta` being the polar, `phi`
-    the azimuthal angle. Note that this meaning is often reversed in physics,
-    cf. <http://mathworld.wolfram.com/SphericalCoordinates.html>.
+    '''Quadrature where `f` is a function of the spherical coordinates
+    `azimuthal` and `polar` (in this order).
     '''
-    rr = numpy.swapaxes(rule.phi_theta, 0, -2)
+    rr = numpy.swapaxes(rule.azimuthal_polar, 0, -2)
     ff = numpy.array(f(rr.T))
     return area(radius) * sumfun(rule.weights * ff, axis=-1)

--- a/test/test_sphere.py
+++ b/test/test_sphere.py
@@ -48,9 +48,9 @@ def test_scheme_cartesian(scheme, tol):
 
     def sph_tree_cartesian(x):
         flt = numpy.vectorize(float)
-        phi_theta = cartesian_to_spherical(flt(x).T).T
+        azimuthal, polar = cartesian_to_spherical(flt(x).T).T
         return numpy.concatenate(orthopy.sphere.sph_tree(
-            scheme.degree+1, phi_theta[1], phi_theta[0]
+            scheme.degree+1, polar, azimuthal
             ))
 
     vals = quadpy.sphere.integrate(
@@ -110,10 +110,11 @@ def test_scheme_spherical(scheme, tol):
 
     flt = numpy.vectorize(float)
 
-    def sph_tree(phi_theta):
-        phi_theta = flt(phi_theta)
+    def sph_tree(azimuthal_polar):
+        azimuthal_polar = flt(azimuthal_polar)
+        azimuthal, polar = azimuthal_polar
         return numpy.concatenate(orthopy.sphere.sph_tree(
-            scheme.degree+1, phi_theta[1], phi_theta[0]
+            scheme.degree+1, polar, azimuthal
             ))
 
     vals = quadpy.sphere.integrate_spherical(

--- a/tools/import_lebedev.py
+++ b/tools/import_lebedev.py
@@ -23,9 +23,9 @@ else:
 
 def read(filename):
     data = numpy.loadtxt(filename)
-    phi_theta = data[:, :2] / 180.0
+    azimuthal_polar = data[:, :2] / 180.0
     weights = data[:, 2]
-    return phi_theta, weights
+    return azimuthal_polar, weights
 
 
 def chunk_data(weights):
@@ -43,7 +43,7 @@ def chunk_data(weights):
     return chunks
 
 
-def sort_into_symmetry_classes(weights, phi_theta):
+def sort_into_symmetry_classes(weights, azimuthal_polar):
     data = []
     for c in chunks:
         if len(c) == 6:
@@ -53,43 +53,47 @@ def sort_into_symmetry_classes(weights, phi_theta):
         elif len(c) == 8:
             data.append({'type': 'a3', 'weight': weights[c[0]]})
         elif len(c) == 24:
-            if any(abs(phi_theta[c, 1] - 0.5) < 1.0e-12):
-                # theta == pi/2   =>   X == [p, q, 0].
-                # Find the smallest positive phi that's paired with `theta ==
+            if any(abs(azimuthal_polar[c, 1] - 0.5) < 1.0e-12):
+                # polar == pi/2   =>   X == [p, q, 0].
+                # Find the smallest positive phi that's paired with `polar ==
                 # pi/2`; the symmetry is fully characterized by that phi.
-                k = numpy.where(abs(phi_theta[c, 1] - 0.5) < 1.0e-12)[0]
+                k = numpy.where(abs(azimuthal_polar[c, 1] - 0.5) < 1.0e-12)[0]
                 assert len(k) == 8
-                k2 = numpy.where(phi_theta[c, 0][k] > 0.0)[0]
-                phi_min = numpy.min(phi_theta[c, 0][k][k2])
+                k2 = numpy.where(azimuthal_polar[c, 0][k] > 0.0)[0]
+                azimuthal_min = numpy.min(azimuthal_polar[c, 0][k][k2])
                 data.append({
-                    'type': 'pq0', 'weight': weights[c[0]], 'val': phi_min
+                    'type': 'pq0',
+                    'weight': weights[c[0]],
+                    'val': azimuthal_min
                     })
             else:
                 # X = [l, l, m].
                 # In this case, there must by exactly two phi with the value
-                # pi/4. Take the value of the smaller corresponding `theta`;
+                # pi/4. Take the value of the smaller corresponding `polar`;
                 # all points are characterized by it.
-                k = numpy.where(abs(phi_theta[c, 0] - 0.25) < 1.0e-12)[0]
+                k = numpy.where(abs(azimuthal_polar[c, 0] - 0.25) < 1.0e-12)[0]
                 assert len(k) == 2
-                k2 = numpy.where(phi_theta[c, 1][k] > 0.0)[0]
-                theta_min = numpy.min(phi_theta[c, 1][k][k2])
+                k2 = numpy.where(azimuthal_polar[c, 1][k] > 0.0)[0]
+                polar_min = numpy.min(azimuthal_polar[c, 1][k][k2])
                 data.append({
-                    'type': 'llm', 'weight': weights[c[0]], 'val': theta_min
+                    'type': 'llm', 'weight': weights[c[0]], 'val': polar_min
                     })
         else:
             assert len(c) == 48
             # This most general symmetry is characterized by two angles; one
             # could take any two here.
-            # To make things easier later on, out of the 6 smallest theta, take
-            # the one with the smallest positive phi.
-            min_theta = numpy.min(phi_theta[c, 1])
-            k = numpy.where(abs(phi_theta[c, 1] - min_theta) < 1.0e-12)[0]
-            k2 = numpy.where(phi_theta[c, 0][k] > 0.0)[0]
-            min_phi = numpy.min(phi_theta[c, 0][k][k2])
+            # To make things easier later on, out of the 6 smallest polar
+            # angle, take the one with the smallest positive phi.
+            min_polar = numpy.min(azimuthal_polar[c, 1])
+            k = numpy.where(
+                abs(azimuthal_polar[c, 1] - min_polar) < 1.0e-12
+                )[0]
+            k2 = numpy.where(azimuthal_polar[c, 0][k] > 0.0)[0]
+            min_azimuthal = numpy.min(azimuthal_polar[c, 0][k][k2])
             data.append({
                 'type': 'rSW',
                 'weight': weights[c[0]],
-                'val': (min_phi, min_theta)
+                'val': (min_azimuthal, min_polar)
                 })
 
     return data
@@ -143,11 +147,11 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     for filename in args.filenames:
-        phi_theta, weights = read(filename)
+        azimuthal_polar, weights = read(filename)
         m = re.match('lebedev_([0-9]+).txt', filename)
         degree = int(m.group(1))
         print('elif degree == {}:'.format(degree))
         chunks = chunk_data(weights)
-        data = sort_into_symmetry_classes(weights, phi_theta)
+        data = sort_into_symmetry_classes(weights, azimuthal_polar)
         out = generate_python_code(data)
         print(indent(out, 4))


### PR DESCRIPTION
This avoids confusion about the different conventions of phi and theta.