### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,13 @@ that a wide variety of function, even seemingly difficult ones with
 _arbitrary_ precision.
 ```python
 from mpmath import mp
+import sympy
 
 mp.dps = 50
 
 val, error_estimate = quadpy.line_segment.tanh_sinh(
-        lambda x: mp.exp(t) * sympy.cos(t),
-        [0, mp.pi/2],
+        lambda x: mp.exp(x) * sympy.cos(x),
+        0, mp.pi/2,
         1.0e-50  # !
         )
 ```


### PR DESCRIPTION
The example of tanh-sinh quadrature is broken. Here is a fix :)

Tested on version 0.11.4 with Python 2.7.5.