### PR TITLE
DOC: rename simplex nsimplex in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ val = quadpy.e2r2.integrate(
 Example:
 ```python
 dim = 4
-val = quadpy.simplex.integrate(
+val = quadpy.nsimplex.integrate(
     lambda x: numpy.exp(x[0]),
     numpy.array([
         [0.0, 0.0, 0.0, 0.0],
@@ -564,7 +564,7 @@ val = quadpy.simplex.integrate(
         [0.0, 3.0, 1.0, 0.0],
         [0.0, 0.0, 4.0, 1.0],
         ]),
-    quadpy.simplex.GrundmannMoeller(dim, 3)
+    quadpy.nsimplex.GrundmannMoeller(dim, 3)
     )
 ```
 


### PR DESCRIPTION
The example of `nsimplex` in `README.md` hadn't been updated since the subpackage was renamed from `simplex` in c9f2192.