### PR TITLE
Fix plotting of non-square quadrilaterals.

### DIFF
--- a/quadpy/quadrilateral/_helpers.py
+++ b/quadpy/quadrilateral/_helpers.py
@@ -41,10 +41,13 @@ class QuadrilateralScheme(NCubeScheme):
         """
         import matplotlib.pyplot as plt
 
-        plt.plot(quad[0][0], quad[1][0], "-k")
-        plt.plot(quad[1][0], quad[1][1], "-k")
-        plt.plot(quad[1][1], quad[0][1], "-k")
-        plt.plot(quad[0][1], quad[0][0], "-k")
+        def plot_segment(a, b):
+            plt.plot((a[0], b[0]), (a[1], b[1]), "-k")
+
+        plot_segment(quad[0][0], quad[1][0])
+        plot_segment(quad[1][0], quad[1][1])
+        plot_segment(quad[1][1], quad[0][1])
+        plot_segment(quad[0][1], quad[0][0])
 
         if not show_axes:
             plt.gca().set_axis_off()


### PR DESCRIPTION
Thank you for your work on this nice library! Here is a small bug fix.

MWE of issue:
```python
import numpy as np
import quadpy
import matplotlib.pyplot as plt

quadri = np.array([[[0.0, 0.0], [0.0, 1.0]], [[1.0, 0.0], [0.8, 0.8]]])
quadrature = quadpy.quadrilateral.sommariva_04()
quadrature.plot(quad=quadri)
plt.show()
```
(I'm not sure how to automatically test for this.)