### PR TITLE
enh: allowed integrate keywords for fine-tuning

### DIFF
--- a/quadpy/line_segment/_newton_cotes.py
+++ b/quadpy/line_segment/_newton_cotes.py
@@ -6,7 +6,7 @@ import sympy
 from ._helpers import LineSegmentScheme
 
 
-def newton_cotes_closed(index):
+def newton_cotes_closed(index, **kwargs):
     """
     Closed Newton-Cotes formulae.
     <https://en.wikipedia.org/wiki/Newton%E2%80%93Cotes_formulas#Closed_Newton.E2.80.93Cotes_formulae>,
@@ -28,7 +28,7 @@ def newton_cotes_closed(index):
         alpha = (
             2
             * (-1) ** (n - r)
-            * sympy.integrate(f, (t, 0, n))
+            * sympy.integrate(f, (t, 0, n), **kwargs)
             / (math.factorial(r) * math.factorial(n - r))
             / index
         )
@@ -36,7 +36,7 @@ def newton_cotes_closed(index):
     return LineSegmentScheme("Newton-Cotes (closed)", degree, weights, points)
 
 
-def newton_cotes_open(index):
+def newton_cotes_open(index, **kwargs):
     """
     Open Newton-Cotes formulae.
     <https://math.stackexchange.com/a/1959071/36678>
@@ -53,7 +53,7 @@ def newton_cotes_open(index):
         alpha = (
             2
             * (-1) ** (n - r + 1)
-            * sympy.integrate(f, (t, 0, n))
+            * sympy.integrate(f, (t, 0, n), **kwargs)
             / (math.factorial(r - 1) * math.factorial(n - 1 - r))
             / n
         )

--- a/quadpy/tools/main.py
+++ b/quadpy/tools/main.py
@@ -161,7 +161,7 @@ def chebyshev_modified(nu, a, b):
     return alpha, beta
 
 
-def integrate(f, a, b):
+def integrate(f, a, b, **kwargs):
     """Symbolically calculate the integrals
 
       int_a^b f_k(x) dx.
@@ -172,9 +172,11 @@ def integrate(f, a, b):
             lambda x: [x**k for k in range(5)],
             -1, +1
             )
+
+    Any keyword arguments are passed directly to `sympy.integrate` function.
     """
     x = sympy.Symbol("x")
-    return numpy.array([sympy.integrate(fun, (x, a, b)) for fun in f(x)])
+    return numpy.array([sympy.integrate(fun, (x, a, b), **kwargs) for fun in f(x)])
 
 
 def coefficients_from_gauss(points, weights):

--- a/quadpy/tools/main.py
+++ b/quadpy/tools/main.py
@@ -64,7 +64,7 @@ def golub_welsch(moments):
     return alpha, beta
 
 
-def stieltjes(w, a, b, n):
+def stieltjes(w, a, b, n, **kwargs):
     t = sympy.Symbol("t")
 
     alpha = n * [None]
@@ -74,20 +74,20 @@ def stieltjes(w, a, b, n):
 
     k = 0
     pi[k] = 1
-    mu[k] = sympy.integrate(pi[k] ** 2 * w(t), (t, a, b))
-    alpha[k] = sympy.integrate(t * pi[k] ** 2 * w(t), (t, a, b)) / mu[k]
+    mu[k] = sympy.integrate(pi[k] ** 2 * w(t), (t, a, b), **kwargs)
+    alpha[k] = sympy.integrate(t * pi[k] ** 2 * w(t), (t, a, b), **kwargs) / mu[k]
     beta[k] = mu[0]  # not used, by convention mu[0]
 
     k = 1
     pi[k] = (t - alpha[k - 1]) * pi[k - 1]
-    mu[k] = sympy.integrate(pi[k] ** 2 * w(t), (t, a, b))
-    alpha[k] = sympy.integrate(t * pi[k] ** 2 * w(t), (t, a, b)) / mu[k]
+    mu[k] = sympy.integrate(pi[k] ** 2 * w(t), (t, a, b), **kwargs)
+    alpha[k] = sympy.integrate(t * pi[k] ** 2 * w(t), (t, a, b), **kwargs) / mu[k]
     beta[k] = mu[k] / mu[k - 1]
 
     for k in range(2, n):
         pi[k] = (t - alpha[k - 1]) * pi[k - 1] - beta[k - 1] * pi[k - 2]
-        mu[k] = sympy.integrate(pi[k] ** 2 * w(t), (t, a, b))
-        alpha[k] = sympy.integrate(t * pi[k] ** 2 * w(t), (t, a, b)) / mu[k]
+        mu[k] = sympy.integrate(pi[k] ** 2 * w(t), (t, a, b), **kwargs)
+        alpha[k] = sympy.integrate(t * pi[k] ** 2 * w(t), (t, a, b), **kwargs) / mu[k]
         beta[k] = mu[k] / mu[k - 1]
 
     return alpha, beta


### PR DESCRIPTION
Allowed users to manually pass keyword arguments to `sympy` integrate function

This enables user control over functions that require special attention, say `manual=True`.