### PR TITLE
Change int datatype check to int_ instead of int64

### DIFF
--- a/quadpy/e2r/_helpers.py
+++ b/quadpy/e2r/_helpers.py
@@ -14,14 +14,14 @@ class E2rScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/e2r2/_helpers.py
+++ b/quadpy/e2r2/_helpers.py
@@ -14,14 +14,14 @@ class E2r2Scheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/e3r/_helpers.py
+++ b/quadpy/e3r/_helpers.py
@@ -12,14 +12,14 @@ class E3rScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/e3r2/_helpers.py
+++ b/quadpy/e3r2/_helpers.py
@@ -12,14 +12,14 @@ class E3r2Scheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/enr/_helpers.py
+++ b/quadpy/enr/_helpers.py
@@ -11,14 +11,14 @@ class EnrScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/enr2/_helpers.py
+++ b/quadpy/enr2/_helpers.py
@@ -11,14 +11,14 @@ class Enr2Scheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/hexahedron/_helpers.py
+++ b/quadpy/hexahedron/_helpers.py
@@ -16,14 +16,14 @@ class HexahedronScheme(NCubeScheme):
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/nball/_helpers.py
+++ b/quadpy/nball/_helpers.py
@@ -13,14 +13,14 @@ class NBallScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/ncube/_helpers.py
+++ b/quadpy/ncube/_helpers.py
@@ -15,14 +15,14 @@ class NCubeScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/nsimplex/_helpers.py
+++ b/quadpy/nsimplex/_helpers.py
@@ -15,14 +15,14 @@ class NSimplexScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/nsphere/_helpers.py
+++ b/quadpy/nsphere/_helpers.py
@@ -14,14 +14,14 @@ class NSphereScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/pyramid/_helpers.py
+++ b/quadpy/pyramid/_helpers.py
@@ -12,14 +12,14 @@ class PyramidScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/quadrilateral/_helpers.py
+++ b/quadpy/quadrilateral/_helpers.py
@@ -16,14 +16,14 @@ class QuadrilateralScheme(NCubeScheme):
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/sphere/_helpers.py
+++ b/quadpy/sphere/_helpers.py
@@ -11,21 +11,21 @@ class SphereScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
 
         if azimuthal_polar.dtype == numpy.float64:
             self.azimuthal_polar = azimuthal_polar
         else:
-            assert azimuthal_polar.dtype in [numpy.dtype("O"), numpy.int64]
+            assert azimuthal_polar.dtype in [numpy.dtype("O"), numpy.int_]
             self.azimuthal_polar = azimuthal_polar.astype(numpy.float64)
             self.azimuthal_polar_symbolic = azimuthal_polar
         return

--- a/quadpy/tetrahedron/_helpers.py
+++ b/quadpy/tetrahedron/_helpers.py
@@ -14,14 +14,14 @@ class TetrahedronScheme(NSimplexScheme):
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/triangle/_helpers.py
+++ b/quadpy/triangle/_helpers.py
@@ -14,14 +14,14 @@ class TriangleScheme(NSimplexScheme):
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return

--- a/quadpy/wedge/_helpers.py
+++ b/quadpy/wedge/_helpers.py
@@ -12,14 +12,14 @@ class WedgeScheme:
         if weights.dtype == numpy.float64:
             self.weights = weights
         else:
-            assert weights.dtype in [numpy.dtype("O"), numpy.int64]
+            assert weights.dtype in [numpy.dtype("O"), numpy.int_]
             self.weights = weights.astype(numpy.float64)
             self.weights_symbolic = weights
 
         if points.dtype == numpy.float64:
             self.points = points
         else:
-            assert points.dtype in [numpy.dtype("O"), numpy.int64]
+            assert points.dtype in [numpy.dtype("O"), numpy.int_]
             self.points = points.astype(numpy.float64)
             self.points_symbolic = points
         return


### PR DESCRIPTION
Since default int datatype is platform-dependent (see [this NumPy issue](https://github.com/numpy/numpy/issues/9464)), quadrature scheme generation will fail when ints are present e.g. on Windows 64-bit machines. 
Checking for the default int type (numpy.int_) instead of numpy.int64 should make this behave as intended on both unix (where numpy.int64 is default) and Windows. Of course, having int_ be platform dependent is not ideal in the first place.